### PR TITLE
build-docker-image.yml: remove deprecated set-output

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -29,8 +29,8 @@ jobs:
             --queryformat="%{EPOCH}:%{VERSION}-%{RELEASE}" \
             osbuild.noarch)
           echo "LATEST_VERSION=${LATEST_VERSION}"
-          echo "::set-output name=osbuild_version::${LATEST_VERSION}"
-          echo "::set-output name=container_tag::$(echo ${LATEST_VERSION} | tr : .)"
+          echo "osbuild_version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+          echo "container_tag=$(echo ${LATEST_VERSION} | tr : .)" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
The syntax to share environment variables from one job to another has been updated and the old style [deprecated][1].

This commit refreshes the code to the new syntax.

[1]: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/