### PR TITLE
Containerfile: switch to fedora 38

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:36
+FROM fedora:38
 
 ARG OSBUILD_VERSION=
 


### PR DESCRIPTION
Switch the base image from Fedora 36 to Fedora 38 to pull newer osbuild versions.