### PR TITLE
build-docker-image.yml: switch to Fedora 38

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt install dnf
           export LATEST_VERSION
           LATEST_VERSION=$(dnf repoquery \
-            --repofrompath "osbuild,https://download.copr.fedorainfracloud.org/results/%40osbuild/osbuild/fedora-36-x86_64" \
+            --repofrompath "osbuild,https://download.copr.fedorainfracloud.org/results/%40osbuild/osbuild/fedora-38-x86_64" \
             --repoid=osbuild \
             --latest-limit 1 \
             --queryformat="%{EPOCH}:%{VERSION}-%{RELEASE}" \


### PR DESCRIPTION
The GitHub actions workflow probed the Fedora 36 copr builds for OSBuild to find the latest version but it seems the builds are outdated for this version.

Switch to probe Fedora 38 to get more up-to-date versions and to match the change in the Containerfile to also use Fedora 38.